### PR TITLE
Added collection loading integration test

### DIFF
--- a/pkg/migrate/migrator_integration_test.go
+++ b/pkg/migrate/migrator_integration_test.go
@@ -26,6 +26,15 @@ func TestTimeoutConnectionToDatabase(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestCollectionDiscovery(t *testing.T) {
+	migr := migrator(t)
+	exp := []string{"_integration_test_collection"}
+	act, err := migr.Collections()
+	assert.NoError(t, err)
+	assert.Equal(t, exp, act)
+	reset(migr, "_integration_test_collection")
+}
+
 func TestDocumentIdDiscovery(t *testing.T) {
 	migr := migrator(t)
 	exp := []string{"a", "b", "c", "d", "e"}

--- a/pkg/migrate/migrator_integration_test.go
+++ b/pkg/migrate/migrator_integration_test.go
@@ -26,7 +26,7 @@ func TestTimeoutConnectionToDatabase(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestCollectionNameDiscovery(t *testing.T) {
+func TestDocumentIdDiscovery(t *testing.T) {
 	migr := migrator(t)
 	exp := []string{"a", "b", "c", "d", "e"}
 	act, err := migr.DocumentIds("_integration_test_collection")


### PR DESCRIPTION
So, this PR adds a test case which tests the discovery of collection names. It was missing, so it should bump up the code coverage a bit